### PR TITLE
Updating/Fixing Dashboard E2E tests

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -4,6 +4,5 @@
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
     <add key="testTools" value="\\vwdbuild01\FxtTestTools\InternalNugetFeed" />
-    <add key="productSnap" value="\\scratch2\scratch\victorhu\dashboarde2e\" />
   </packageSources>
 </configuration>

--- a/test/Dashboard.EndToEndTests/Dashboard.EndToEndTests.csproj
+++ b/test/Dashboard.EndToEndTests/Dashboard.EndToEndTests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ExplicitTypeLocator.cs" />
     <Compile Include="Tests\ArgumentsDisplay\BlobArgumentsDisplayFunctions.cs" />
     <Compile Include="Tests\ArgumentsDisplay\BlobArgumentsDisplayFixture.cs" />
     <Compile Include="Tests\ArgumentsDisplay\QueueArgumentsDisplayFixture.cs" />
@@ -110,17 +111,13 @@
     <Compile Include="Tests\ConnectionStrings\NoConnectionStringTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.WebJobs, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Azure.WebJobs, Version=1.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.0.7.0-beta\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.0.1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.0.7.0-beta\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Host.TestCommon, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Host.TestCommon.0.7.0-beta\lib\net45\Microsoft.Azure.WebJobs.Host.TestCommon.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.0.1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -196,7 +193,9 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/test/Dashboard.EndToEndTests/ExplicitTypeLocator.cs
+++ b/test/Dashboard.EndToEndTests/ExplicitTypeLocator.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs;
+
+namespace Dashboard.EndToEndTests
+{
+    public class ExplicitTypeLocator : ITypeLocator
+    {
+        private readonly Type[] _types;
+
+        public ExplicitTypeLocator(params Type[] types)
+        {
+            _types = types;
+        }
+
+        public IReadOnlyList<Type> GetTypes()
+        {
+            return _types;
+        }
+    }
+}

--- a/test/Dashboard.EndToEndTests/Tests/ArgumentsDisplay/BlobArgumentsDisplayFixture.cs
+++ b/test/Dashboard.EndToEndTests/Tests/ArgumentsDisplay/BlobArgumentsDisplayFixture.cs
@@ -4,7 +4,6 @@
 using System.Reflection;
 using System.Threading;
 using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace Dashboard.EndToEndTests
@@ -53,7 +52,7 @@ namespace Dashboard.EndToEndTests
 
             JobHostConfiguration hostConfiguration = new JobHostConfiguration(StorageAccount.ConnectionString)
             {
-                TypeLocator = new SimpleTypeLocator(
+                TypeLocator = new ExplicitTypeLocator(
                     typeof(BlobArgumentsDisplayFunctions),
                     typeof(BlobArgumentsDisplayFunctions.POCOBinder),
                     typeof(DoneNotificationFunction))

--- a/test/Dashboard.EndToEndTests/Tests/ArgumentsDisplay/QueueArgumentsDisplayFixture.cs
+++ b/test/Dashboard.EndToEndTests/Tests/ArgumentsDisplay/QueueArgumentsDisplayFixture.cs
@@ -4,7 +4,6 @@
 using System.Reflection;
 using System.Threading;
 using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.WindowsAzure.Storage.Queue;
 
 namespace Dashboard.EndToEndTests
@@ -43,7 +42,7 @@ namespace Dashboard.EndToEndTests
 
             JobHostConfiguration hostConfiguration = new JobHostConfiguration(StorageAccount.ConnectionString)
             {
-                TypeLocator = new SimpleTypeLocator(
+                TypeLocator = new ExplicitTypeLocator(
                     typeof(QueueArgumentsDisplayFunctions),
                     typeof(DoneNotificationFunction))
             };

--- a/test/Dashboard.EndToEndTests/Tests/ConnectionStrings/NoConnectionStringTests.cs
+++ b/test/Dashboard.EndToEndTests/Tests/ConnectionStrings/NoConnectionStringTests.cs
@@ -38,13 +38,23 @@ namespace Dashboard.EndToEndTests
             JobsPage page = Dashboard.GoToJobsPage();
             
             // Verify navbar buttons
-            IEnumerable<Link> links = page.Navbar.NavLinks;
-            Assert.Equal(1, links.Count());
+            Link[] links = page.Navbar.NavLinks.ToArray();
+            Assert.Equal(3, links.Length);
 
-            Link functionLink = links.First();
+            Link functionLink = links[0];
             Assert.True(functionLink.IsUserAccesible);
             Assert.Equal("Functions", functionLink.Text);
             Assert.Equal(Dashboard.BuildFullUrl(FunctionsPage.RelativePath), functionLink.Href);
+
+            Link blobSearchLink = links[1];
+            Assert.True(blobSearchLink.IsUserAccesible);
+            Assert.Equal("Search Blobs", blobSearchLink.Text);
+            Assert.Equal(Dashboard.BuildFullUrl(SearchBlobPage.RelativePath), blobSearchLink.Href);
+
+            Link aboutLink = links[2];
+            Assert.True(aboutLink.IsUserAccesible);
+            Assert.Equal("About", aboutLink.Text);
+            Assert.Equal(Dashboard.BuildFullUrl("#/about"), aboutLink.Href);
         }
 
         [Fact]
@@ -67,16 +77,6 @@ namespace Dashboard.EndToEndTests
 
             Assert.Equal(3, noJobsCell.ColSpan);
             Assert.Equal("There are no WebJobs in this website. See this article about using WebJobs.", noJobsCell.RawElement.Text);
-        }
-
-        [Fact]
-        public void FunctionsPage_SdkTeaser()
-        {
-            FunctionsPage page = Dashboard.GoToFunctionsPage();
-
-            SdkTeaserNotification sdkTeaserNotification = page.SdkTeaserNotificationSection.SdkTeaserNotification;
-            Assert.True(sdkTeaserNotification.IsUserAccesible);
-            Assert.Equal("http://go.microsoft.com/fwlink/?LinkID=320954", sdkTeaserNotification.MoreInfoUrl.Href);
         }
     }
 }

--- a/test/Dashboard.EndToEndTests/Tests/IndexedFunctions/FunctionWithInvocationsTests.cs
+++ b/test/Dashboard.EndToEndTests/Tests/IndexedFunctions/FunctionWithInvocationsTests.cs
@@ -11,7 +11,6 @@ using Dashboard.EndToEndTests.HtmlAbstractions.Angular;
 using Dashboard.EndToEndTests.Infrastructure;
 using Dashboard.EndToEndTests.Infrastructure.DashboardData;
 using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Xunit;
 
 namespace Dashboard.EndToEndTests
@@ -23,7 +22,7 @@ namespace Dashboard.EndToEndTests
         {
             JobHostConfiguration hostConfiguration = new JobHostConfiguration(StorageAccount.ConnectionString)
             {
-                TypeLocator = new SimpleTypeLocator(typeof(SingleFunction))
+                TypeLocator = new ExplicitTypeLocator(typeof(SingleFunction))
             };
 
             JobHost host = new JobHost(hostConfiguration);

--- a/test/Dashboard.EndToEndTests/Tests/IndexedFunctions/FunctionWithoutInvocationsTests.cs
+++ b/test/Dashboard.EndToEndTests/Tests/IndexedFunctions/FunctionWithoutInvocationsTests.cs
@@ -9,7 +9,6 @@ using Dashboard.EndToEndTests.DomAbstractions;
 using Dashboard.EndToEndTests.HtmlAbstractions;
 using Dashboard.EndToEndTests.Infrastructure;
 using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Xunit;
 
 namespace Dashboard.EndToEndTests
@@ -21,7 +20,7 @@ namespace Dashboard.EndToEndTests
         {
             JobHostConfiguration hostConfiguration = new JobHostConfiguration(StorageAccount.ConnectionString)
             {
-                TypeLocator = new SimpleTypeLocator(typeof(SingleFunction))
+                TypeLocator = new ExplicitTypeLocator(typeof(SingleFunction))
             };
 
             JobHost host = new JobHost(hostConfiguration);

--- a/test/Dashboard.EndToEndTests/packages.config
+++ b/test/Dashboard.EndToEndTests/packages.config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.WebJobs" version="0.7.0-beta" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="0.7.0-beta" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs.Host.TestCommon" version="0.7.0-beta" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />


### PR DESCRIPTION
The Dashboard tests are currently failing on http://wsr-tc. Getting them running again by updating to the latest WebJobs SDK version, and fixing a few test issues.
